### PR TITLE
Support for spaces in files and *.hpp includes

### DIFF
--- a/bash/genfilters.sh
+++ b/bash/genfilters.sh
@@ -42,7 +42,7 @@ function listfilters(){
 
 function listothers(){
  echo "  <ItemGroup>"
- for i in $(find . -not -path '*/\.*' -type f ! -iname "*.c" ! -iname "*.cpp" ! -iname "*.h" ! -iname "*.txt" ! -iname "*.o" ! -iname "*.vcxproj")
+ for i in $(find . -not -path '*/\.*' -type f ! -iname "*.c" ! -iname "*.cpp" ! -iname "*.h" ! -iname "*.hpp" ! -iname "*.txt" ! -iname "*.o" ! -iname "*.vcxproj")
  do
    d=${i%/*}
    fd=${d##*/}
@@ -113,7 +113,7 @@ done
 
 function listinclude(){
  echo "  <ItemGroup>"
- for i in $(find . -not -path '*/\.*' -type f -iname "*.h")
+ for i in $(find . -not -path '*/\.*' -type f -iname "*.h" -or -iname "*.hpp")
  do
    d=${i%/*}
    fd=${d##*/}
@@ -135,6 +135,8 @@ function listinclude(){
  echo "  </ItemGroup>"
 }
 
+OLDIFS=$IFS
+IFS=$'\n'
 cd $1 || exit 2;
 touch $2 && test -w $2 || exit 2;
 windir=$3
@@ -145,4 +147,5 @@ listtxt >> $2
 listcompile >> $2
 listinclude >> $2
 printfooter >> $2
+IFS=$OLDIFS
 exit

--- a/bash/genvcxproj.sh
+++ b/bash/genvcxproj.sh
@@ -116,7 +116,7 @@ function printfooter(){
 
 function listothers(){
  echo "  <ItemGroup>"
- for i in $(find . -not -path '*/\.*' -type f ! -iname "*.c" ! -iname "*.cpp" ! -iname "*.h" ! -iname "*.txt" ! -iname "*.o" ! -iname "*.vcxproj" ! -iname "*.filters")
+ for i in $(find . -not -path '*/\.*' -type f ! -iname "*.c" ! -iname "*.cpp" ! -iname "*.h" ! -iname "*.hpp" ! -iname "*.txt" ! -iname "*.o" ! -iname "*.vcxproj" ! -iname "*.filters")
  do
    d=${i%/*}
    d=${d//\//\\}
@@ -156,7 +156,7 @@ function listcompile(){
 
 function listinclude(){
  echo "  <ItemGroup>"
- for i in $(find . -not -path '*/\.*' -type f -iname "*.h")
+ for i in $(find . -not -path '*/\.*' -type f -iname "*.h" -or -iname "*.hpp")
  do
    d=${i%/*}
    d=${d//\//\\}
@@ -166,7 +166,8 @@ function listinclude(){
  done
  echo "  </ItemGroup>"
 }
-
+OLDIFS=$IFS
+IFS=$'\n'
 cd $1 || exit 2;
 touch $2 && test -w $2 || exit 2;
 windir=$3
@@ -176,4 +177,5 @@ listtxt >> $2
 listcompile >> $2
 listinclude >> $2
 printfooter >> $2
+IFS=$OLDIFS
 exit


### PR DESCRIPTION
Added support for spaces in file paths and *.hpp include files as I needed them for my project. Not sure if the way I did it is correct or proper but it worked fine for a large project (Mapbox GL Native) on Ubuntu 16.04 x64.

Thanks for the scripts!
